### PR TITLE
EE-12142: increase upstream timeout in the config for keycloak proxy

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -107,6 +107,7 @@ spec:
           - --enable-json-logging=true
           - --upstream-url=http://127.0.0.1:8000
           - --upstream-response-header-timeout=101s
+          - --upstream-timeout=101s
           - --no-redirects=false
           - --redirection-url=https://{{.DOMAIN_NAME}}
           - --cors-origins='*'


### PR DESCRIPTION
This in an effort to allow IPS enough time to make a correct response when it has to deal with complicated names.